### PR TITLE
Support for upsert operation on an object level

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,9 +144,7 @@ This is the structure for each sObject
 	"fieldsToExport": "FirstName,LastName,Email,Id",
 	"matchBy": "Email",
 	"orderBy": "LastName",
-	"twoPassReferenceFields": "Foo__c,Bar__c",
-	"where": null,
-	"externalIdField": null
+	"where": null
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,8 @@ You must provide the name of the sObject
 	"ignoreFields": "OwnerId, IgnoreField__c",
 	"maxRecords": 50,
 	"orderBy": "City__c",
-	"where": "State__c = 'Texas'"
+	"where": "State__c = 'Texas'",
+	"externalIdField": "External_Id_Field__c"
 }
 ```
 
@@ -121,6 +122,7 @@ This is the structure for each sObject
 | orderBy                | null    | String    | For exports, determines the order for the records that are exported.                                                       |
 | twoPassReferenceFields | null    | String[]  | For imports, lists the fields that need to be set using a separate update as they refer an SObject that is not loaded yet. |
 | where                  | null    | String    | Restrict which records are be exported.                                                                                    |
+| externalIdField        | null    | String    | API name of external ID field to be used for an upsert operation.                                                                                    |
 
 ## sObjectsMetadata
 
@@ -143,7 +145,8 @@ This is the structure for each sObject
 	"matchBy": "Email",
 	"orderBy": "LastName",
 	"twoPassReferenceFields": "Foo__c,Bar__c",
-	"where": null
+	"where": null,
+	"externalIdField": null
 }
 ```
 

--- a/src/@ELTOROIT/Importer.ts
+++ b/src/@ELTOROIT/Importer.ts
@@ -1,4 +1,4 @@
-import { BulkOptions, Date, RecordResult } from "jsforce";
+import { BulkOptions, Date, RecordResult, RestApiOptions } from "jsforce";
 import { ISchemaDataParent } from "./Interfaces";
 import { OrgManager } from "./OrgManager";
 import { LogLevel, ResultOperation, Util } from "./Util";
@@ -90,7 +90,7 @@ export class Importer {
 					this.countImportErrorsRecords = 0;
 					this.countImportErrorsSObjects = 0;
 					const sObjectsToLoad: string[] = orgDestination.order.findImportOrder();
-					Util.writeLog("sObjects should be processed in this order: " + sObjectsToLoad, LogLevel.TRACE);
+					Util.writeLog("sObjects should be processed in this order: " + sObjectsToLoad.join(", "), LogLevel.TRACE);
 					return this.loadAllSObjectData(orgSource, orgDestination, sObjectsToLoad, 0);
 				})
 				.then(() => {
@@ -298,17 +298,7 @@ export class Importer {
 					});
 
 					if (records.length > 0) {
-						// LOADING
-						this.matchingIds.set(sObjName, new Map<string, string>());
-						orgDestination.conn.bulk.pollTimeout = orgDestination.settings.pollingTimeout;
-						// WARNING: Salesforce Bulk has a weird behavior that if the options are not given,
-						// WARNING: then the rest of the parameters are shifted to the left rather than taking null as a placeholder.
-						const bulkOptions: BulkOptions = { concurrencyMode: "Parallel", extIdField: orgDestination.settings.getSObjectData(sObjName).externalIdField || null };
-						// LEARNING: Inserting sObject records in bulk
-						const operation = orgDestination.settings.getSObjectData(sObjName).externalIdField ? "upsert" : "insert";
-						Util.writeLog(`Importing [${sObjName}] using [${operation}] with options [${JSON.stringify(bulkOptions)}]`, LogLevel.DEBUG);
-
-						orgDestination.conn.bulk.load(sObjName, operation, bulkOptions, this.getRecordsForOperation(records, operation), (error, results: any[]) => {
+						const processResults = (error, results: any[]) => {
 							let badCount: number = 0;
 							let goodCount: number = 0;
 
@@ -342,7 +332,30 @@ export class Importer {
 							Util.logResultsAdd(orgDestination, ResultOperation.IMPORT, sObjName, goodCount, badCount);
 
 							resolve(badCount);
-						});
+						};
+
+						// LOADING
+						this.matchingIds.set(sObjName, new Map<string, string>());
+						// ELTOROIT: Bulk or SOAP?
+						const operation = orgDestination.settings.getSObjectData(sObjName).externalIdField ? "upsert" : "insert";
+						if (orgDestination.settings.useBulkAPI) {
+							// WARNING: Salesforce Bulk has a weird behavior that if the options are not given,
+							// WARNING: then the rest of the parameters are shifted to the left rather than taking null as a placeholder.
+							orgDestination.conn.bulk.pollTimeout = orgDestination.settings.pollingTimeout;
+							const options: BulkOptions = { concurrencyMode: "Parallel", extIdField: orgDestination.settings.getSObjectData(sObjName).externalIdField || null };
+
+							Util.writeLog(`Importing [${sObjName}] using [${operation}] with options [${JSON.stringify(options)}]`, LogLevel.DEBUG);
+							
+							// LEARNING: Inserting sObject records in bulk
+							orgDestination.conn.bulk.load(sObjName, operation, options, this.getRecordsForOperation(records, operation), processResults);
+						} else {
+							const options: RestApiOptions = { allOrNone: true, allowRecursive: true };
+							if (operation === "insert") {
+								orgDestination.conn.sobject(sObjName).create(records, options, processResults);
+							} else {
+								orgDestination.conn.sobject(sObjName).upsert(records, orgDestination.settings.getSObjectData(sObjName).externalIdField, options, processResults);
+							}
+						}
 					} else {
 						resolve(0);
 					}
@@ -370,7 +383,6 @@ export class Importer {
 		return new Promise((resolve, reject) => {
 			// WARNING: Salesforce Bulk has a weird behavior that if the options are not given,
 			// WARNING: then the rest of the parameters are shifted to the left rather than taking null as a placeholder.
-			const bulkOptions: BulkOptions = { concurrencyMode: "Parallel", extIdField: null };
 			const keys: Array<string> = Array.from(this.twoPassReferenceFieldData.keys());
 
 			Util.serialize(
@@ -414,8 +426,8 @@ export class Importer {
 							records.push(record);
 						});
 
-						// Update the records using the bulk api
-						orgDestination.conn.bulk.load(sObjectName, "update", bulkOptions, records, (error, results: any[]) => {
+						// UPDATING the records
+						const processResults = (error, results: any[]) => {
 							let badCount: number = 0;
 							let goodCount: number = 0;
 
@@ -440,7 +452,16 @@ export class Importer {
 							Util.logResultsAdd(orgDestination, ResultOperation.IMPORT, sObjectName, goodCount, badCount);
 
 							resolveEach();
-						});
+						};
+
+						// ELTOROIT: Bulk or SOAP?
+						if (orgDestination.settings.useBulkAPI) {
+							const bulkOptions: BulkOptions = { concurrencyMode: "Parallel", extIdField: null };
+							orgDestination.conn.bulk.load(sObjectName, "update", bulkOptions, records, processResults);
+						} else {
+							const options: RestApiOptions = { allOrNone: true, allowRecursive: true };
+							orgDestination.conn.sobject(sObjectName).update(records, options, processResults);
+						}
 					});
 				}
 			)

--- a/src/@ELTOROIT/Settings.ts
+++ b/src/@ELTOROIT/Settings.ts
@@ -24,6 +24,7 @@ export interface ISettingsSObjectData extends ISettingsSObjectBase {
 	ignoreFields: string | string[];
 	twoPassReferenceFields: string | string[];
 	maxRecords: number;
+	externalIdField: string;
 }
 
 // NOTE: Metadata in the configuration file
@@ -497,7 +498,8 @@ export class Settings implements ISettingsValues {
 			maxRecords: -1,
 			name: sObjName,
 			orderBy: null,
-			where: null
+			where: null,
+			externalIdField: null
 		};
 		// LEARNING: [OBJECT]: How to loop through the values of an JSON object, which is not a Typescript Map.
 		Object.keys(sObject).forEach((key) => {
@@ -645,7 +647,8 @@ export class Settings implements ISettingsValues {
 				maxRecords: this.maxRecordsEachRaw,
 				name: null,
 				orderBy: null,
-				where: null
+				where: null,
+				externalIdField: null
 			};
 			this.blankSObjectData = output;
 		}

--- a/src/@ELTOROIT/Settings.ts
+++ b/src/@ELTOROIT/Settings.ts
@@ -1,5 +1,5 @@
 import { ConfigContents, ConfigFile, fs } from "@salesforce/core";
-import { AnyJson, Dictionary, toAnyJson } from "@salesforce/ts-types";
+import { AnyJson, Dictionary } from "@salesforce/ts-types";
 import { WhichOrg } from "./OrgManager";
 import { LogLevel, Util } from "./Util";
 
@@ -42,6 +42,7 @@ export interface ISettingsValues {
 	includeAllCustom: boolean;
 	stopOnErrors: boolean;
 	copyToProduction: boolean;
+	useBulkAPI: boolean;
 	ignoreFieldsRaw: string;
 	twoPassReferenceFieldsRaw: string;
 	maxRecordsEachRaw: number;
@@ -81,6 +82,7 @@ export class Settings implements ISettingsValues {
 	public includeAllCustom: boolean;
 	public stopOnErrors: boolean;
 	public copyToProduction: boolean;
+	public useBulkAPI: boolean;
 	public maxRecordsEachRaw: number;
 	public deleteDestination: boolean;
 	public pollingTimeout: number;
@@ -366,6 +368,13 @@ export class Settings implements ISettingsValues {
 						})
 					);
 
+					// useBulkAPI
+					promises.push(
+						this.processStringValues(resValues, "useBulkAPI", false).then((value: string) => {
+							this.useBulkAPI = value === "true";
+						})
+					);
+
 					// rootFolder
 					promises.push(
 						this.processStringValues(resValues, "rootFolder", false)
@@ -546,7 +555,8 @@ export class Settings implements ISettingsValues {
 		const output: ConfigContents = {};
 
 		// VERBOSE: Print debug time in output file so files do get changed, and we know we are looking at the right file.
-		output.now = toAnyJson(new Date().toJSON());
+		// Do not update timestamp
+		// output.now = toAnyJson(new Date().toJSON());
 
 		// Output regular data
 		output[WhichOrg.SOURCE] = this.orgAliases.get(WhichOrg.SOURCE);
@@ -558,6 +568,7 @@ export class Settings implements ISettingsValues {
 		output.stopOnErrors = this.stopOnErrors;
 		output.ignoreFields = this.ignoreFieldsRaw;
 		output.copyToProduction = this.copyToProduction;
+		output.useBulkAPI = this.useBulkAPI;
 		output.twoPassReferenceFields = this.twoPassReferenceFieldsRaw;
 		output.maxRecordsEach = this.maxRecordsEachRaw;
 		output.deleteDestination = this.deleteDestination;
@@ -630,6 +641,7 @@ export class Settings implements ISettingsValues {
 		this.includeAllCustom = false;
 		this.stopOnErrors = true;
 		this.copyToProduction = false;
+		this.useBulkAPI = false;
 		this.ignoreFieldsRaw = null;
 		this.twoPassReferenceFieldsRaw = null;
 		this.maxRecordsEachRaw = -1;


### PR DESCRIPTION
Introduced a new field in the object configuration call `externalIdField`, which will trigger an `upsert` operation for the bulk API load using its value as the primary ID identifier. 
Note that the `records` array had to be cloned to remove the ID in order to succeed with the `upsert` since JSForce does remove it automatically for `insert` operations but not for `upsert`. Removing the Id property on the original array would break the ID mapping logic. 
It's very much possible that I missed some changes in the code base. Please let me know if that is the case. 

Would be great to see this in a new version sometime soon. ;) Thanks for this fantastic plugin!

Cheers! 